### PR TITLE
「画像リンクからアップロードする」機能を廃止

### DIFF
--- a/flutter_quill_extensions/lib/embeds/image/editor/image_embed_types.dart
+++ b/flutter_quill_extensions/lib/embeds/image/editor/image_embed_types.dart
@@ -43,7 +43,6 @@ typedef OnImageInsertedCallback = Future<void> Function(
 enum InsertImageSource {
   gallery,
   camera,
-  link,
 }
 
 /// Configurations for dealing with images, on insert a image

--- a/flutter_quill_extensions/lib/embeds/image/toolbar/image_button.dart
+++ b/flutter_quill_extensions/lib/embeds/image/toolbar/image_button.dart
@@ -7,7 +7,6 @@ import 'package:flutter_quill/translations.dart';
 import '../../../models/config/image/toolbar/image_configurations.dart';
 import '../../../models/config/shared_configurations.dart';
 import '../../../services/image_picker/image_picker.dart';
-import '../../others/image_video_utils.dart';
 import '../editor/image_embed_types.dart';
 import 'select_image_source.dart';
 
@@ -138,7 +137,6 @@ class QuillToolbarImageButton extends StatelessWidget {
           source: ImageSource.gallery,
         ))
             ?.path,
-      InsertImageSource.link => await _typeLink(context),
       InsertImageSource.camera => (await imagePickerService.pickImage(
           source: ImageSource.camera,
         ))
@@ -158,17 +156,4 @@ class QuillToolbarImageButton extends StatelessWidget {
     }
   }
 
-  Future<String?> _typeLink(BuildContext context) async {
-    final value = await showDialog<String>(
-      context: context,
-      builder: (_) => FlutterQuillLocalizationsWidget(
-        child: TypeLinkDialog(
-          dialogTheme: options.dialogTheme,
-          linkRegExp: options.linkRegExp,
-          linkType: LinkType.image,
-        ),
-      ),
-    );
-    return value;
-  }
 }

--- a/flutter_quill_extensions/lib/embeds/image/toolbar/image_button.dart
+++ b/flutter_quill_extensions/lib/embeds/image/toolbar/image_button.dart
@@ -79,9 +79,7 @@ class QuillToolbarImageButton extends StatelessWidget {
           iconData: iconData,
           iconSize: iconSize,
           iconButtonFactor: iconButtonFactor,
-          dialogTheme: options.dialogTheme,
           iconTheme: options.iconTheme,
-          linkRegExp: options.linkRegExp,
           tooltip: options.tooltip,
           imageButtonConfigurations: options.imageButtonConfigurations,
         ),
@@ -152,7 +150,7 @@ class QuillToolbarImageButton extends StatelessWidget {
           ?.call(imageUrl);
     }
     } catch (e) {
-      options.imageButtonConfigurations.onErrorCall!(source);
+      options.imageButtonConfigurations.onErrorCall?.call(source);
     }
   }
 

--- a/flutter_quill_extensions/lib/embeds/image/toolbar/select_image_source.dart
+++ b/flutter_quill_extensions/lib/embeds/image/toolbar/select_image_source.dart
@@ -32,14 +32,6 @@ class SelectImageSourceDialog extends StatelessWidget {
               enabled: !isDesktop(supportWeb: false),
               onTap: () => Navigator.of(context).pop(InsertImageSource.camera),
             ),
-            ListTile(
-              title: Text(context.loc.link),
-              subtitle: Text(
-               '画像リンクからアップロードする',
-              ),
-              leading: const Icon(Icons.link),
-              onTap: () => Navigator.of(context).pop(InsertImageSource.link),
-            ),
             const SizedBox(
                                 height: 20,
                                 )

--- a/flutter_quill_extensions/lib/models/config/image/toolbar/image_configurations.dart
+++ b/flutter_quill_extensions/lib/models/config/image/toolbar/image_configurations.dart
@@ -25,15 +25,8 @@ class QuillToolbarImageButtonOptions extends QuillToolbarBaseButtonOptions<
     super.afterButtonPressed,
     super.childBuilder,
     super.iconTheme,
-    this.dialogTheme,
-    this.linkRegExp,
     this.imageButtonConfigurations = const QuillToolbarImageConfigurations(),
   });
-
-  final QuillDialogTheme? dialogTheme;
-
-  /// [imageLinkRegExp] is a regular expression to identify image links.
-  final RegExp? linkRegExp;
 
   final QuillToolbarImageConfigurations imageButtonConfigurations;
 }


### PR DESCRIPTION
「画像リンクからアップロードする」機能と関連コードを削除。

sampleは使えないため、外部アプリのpubspec.yamlから本ブランチを参照して動作確認を実施。